### PR TITLE
Use different config files

### DIFF
--- a/.grenrc
+++ b/.grenrc
@@ -1,0 +1,6 @@
+{
+    "ignoreIssuesWith": [
+        "duplicate",
+        "wontfix"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Following the options for the module:
 
 ### Config file
 
-You can create a `.gren.json` file where the task will be ran, where to specify your options.
+You can create a configuration file where the task will be ran, where to specify your options.
 The options in the file would be camelCase *e.g*:
 
 ```json
@@ -89,7 +89,15 @@ The options in the file would be camelCase *e.g*:
 }
 ```
 
-### Templates
+The accepted file extensions are the following:
+
+- `.grenrc`
+- `.grenrc.json`
+- `.grenrc.yml`
+- `.grenrc.yaml`
+- `.grenrc.js`
+
+#### Templates
 
 You can configure the output of **gren** using templates. Set your own configuration inside the config file, which will be merged with the defaults, shown below:
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "connectivity": "^1.0.0",
     "deep-assign": "^2.0.0",
     "es6-promise": "^3.2.1",
-    "github-api": "^3.0.0"
+    "github-api": "^3.0.0",
+    "require-yaml": "0.0.1"
   },
   "devDependencies": {
     "eslint": "^3.6.0",

--- a/src/gren.js
+++ b/src/gren.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('require-yaml');
 var utils = require('./utils');
 var githubInfo = require('./github-info');
 var template = require('./template');
@@ -10,7 +11,7 @@ var Promise = Promise || require('es6-promise').Promise;
 var connectivity = require('connectivity');
 var templateConfig = require('./templates.json');
 var ObjectAssign = require('deep-assign');
-var configFile = fs.existsSync(process.cwd() + '/.gren.json') ? require(process.cwd() + '/.gren.json') : {};
+var configFile = utils.getConfigFromFile(process.cwd());
 
 var defaults = {
     tags: false,
@@ -120,7 +121,7 @@ function prepareRelease(gren, block) {
 
     if (block.id) {
         if (!gren.options.override) {
-            console.warn(chalk.yellow('Skipping ' + block.release + ' (use --override to replace it)'));
+            console.warn(chalk.black(chalk.bgYellow('Skipping ' + block.release + ' (use --override to replace it)')));
 
             return Promise.resolve();
         }

--- a/src/gren.js
+++ b/src/gren.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('require-yaml');
 var utils = require('./utils');
 var githubInfo = require('./github-info');
 var template = require('./template');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var chalk = require('chalk');
+var fs = require('fs');
 
 /**
 * Print a task name in a custom format
@@ -167,6 +168,49 @@ function formatDate(date) {
     return ('0' + date.getDate()).slice(-2) + '/' + ('0' + (date.getMonth() + 1)).slice(-2) + '/' + date.getFullYear();
 }
 
+/**
+ * Gets the content from a filepath a returns an object
+ *
+ * @since  0.6.0
+ * @public
+ *
+ * @param  {string} filepath
+ * @return {Object|boolean}
+ */
+function requireConfig(filepath) {
+    if (!fs.existsSync(filepath)) {
+        return false;
+    }
+
+    if (filepath.match(/\./g).length === 1) {
+        return JSON.parse(fs.readFileSync(filepath, "utf8"));
+    }
+
+    return require(filepath);
+}
+
+/**
+ * Get configuration from the one of the config files
+ *
+ * @since 0.6.0
+ * @public
+ *
+ * @param  {string} path Path where to look for config files
+ * @return {Object} The configuration from the first found file or empty object
+ */
+function getConfigFromFile(path) {
+    return [
+            '.grenrc.json',
+            '.grenrc.yaml',
+            '.grenrc.yml',
+            '.grenrc.js',
+            '.grenrc'
+        ]
+        .reduce(function(carry, filename) {
+            return carry || requireConfig(path + '/' + filename);
+        }, false) || {};
+}
+
 module.exports = {
     printTask: printTask,
     task: task,
@@ -175,5 +219,6 @@ module.exports = {
     dashToCamelCase: dashToCamelCase,
     isInRange: isInRange,
     convertStringToArray: convertStringToArray,
-    formatDate: formatDate
+    formatDate: formatDate,
+    getConfigFromFile: getConfigFromFile
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@
 
 var chalk = require('chalk');
 var fs = require('fs');
+require('require-yaml');
 
 /**
 * Print a task name in a custom format
@@ -200,9 +201,9 @@ function requireConfig(filepath) {
  */
 function getConfigFromFile(path) {
     return [
+            '.grenrc.yml',
             '.grenrc.json',
             '.grenrc.yaml',
-            '.grenrc.yml',
             '.grenrc.js',
             '.grenrc'
         ]


### PR DESCRIPTION
Closes #39 

Allow the configuration file to be in different extension.

Also allows the configuration to be JavaScript, which might be useful for templating and closes #27.