### PR TITLE
Changelog function

### DIFF
--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+    "prefix": "v",
     "ignoreIssuesWith": [
         "duplicate",
         "wontfix",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,128 +1,141 @@
 # Changelog
 
-## 0.6.3 (13/03/2017)
+## v0.7.2 (17/03/2017)
 
-- [**bug**] Fix multiple repo information [#48](https://github.com/github-tools/github-release-notes/issues/48)
+#### Bug Fixes:
 
+- [#59](https://github.com/github-tools/github-release-notes/issues/59) Changelog action doesn't work in the grunt task
 
- --- 
+---
 
-## 0.6.2 (13/03/2017)
+## v0.7.1 (16/03/2017)
 
-- [**bug**] Remove unused option user.name [#45](https://github.com/github-tools/github-release-notes/issues/45)
+#### Bug Fixes:
 
+- [#57](https://github.com/github-tools/github-release-notes/issues/57) Fix object-deep-assign bug
 
+---
 
- --- 
+## v0.7.0 (16/03/2017)
 
-## 0.6.1 (12/03/2017)
+#### Framework Enhancements:
 
-- [**bug**] Error when there is only one tag [#43](https://github.com/github-tools/github-release-notes/issues/43)
-- [**enhancement**] Use different files type for configuration [#39](https://github.com/github-tools/github-release-notes/issues/39)
+- [#53](https://github.com/github-tools/github-release-notes/issues/53) Allow functions as template values
+- [#50](https://github.com/github-tools/github-release-notes/issues/50) Add GIF in readme.md file
+- [#27](https://github.com/github-tools/github-release-notes/issues/27) Add possibility to change date format
 
+---
 
-
- --- 
-
-## 0.6.0 (11/03/2017)
-
-- [**enhancement**] Unwrap github-api promises [#32](https://github.com/github-tools/github-release-notes/issues/32)
-- [**bug**] Remove escaping character on regex [#29](https://github.com/github-tools/github-release-notes/issues/29)
-- [**enhancement**] Use external config file [#26](https://github.com/github-tools/github-release-notes/issues/26)
-- [**bug**] The changelog action doesn't compile latest release [#24](https://github.com/github-tools/github-release-notes/issues/24)
-- [**enhancement**] Introduce templates for the issues [#23](https://github.com/github-tools/github-release-notes/issues/23)
-- [**enhancement**] Add an "ignore label" flag [#19](https://github.com/github-tools/github-release-notes/issues/19)
-- [**enhancement**] Add the chance to rebuild the history of release notes [#12](https://github.com/github-tools/github-release-notes/issues/12)
-
-
-
- --- 
-
-## 0.5.0 (26/09/2016)
-
-- [**enhancement**] Specify which tag to build [#20](https://github.com/github-tools/github-release-notes/issues/20)
-- [**enhancement**] Create global version of the module [#18](https://github.com/github-tools/github-release-notes/issues/18)
-- [**enhancement**] Update the documentation [#16](https://github.com/github-tools/github-release-notes/issues/16)
-- [**bug**] Manage the scenario where there is only one tag [#15](https://github.com/github-tools/github-release-notes/issues/15)
-- [**enhancement**] Add the chance to override the latest release body [#14](https://github.com/github-tools/github-release-notes/issues/14)
-- [**enhancement**] Check the network [#13](https://github.com/github-tools/github-release-notes/issues/13)
-- [**enhancement**] Add tests [#11](https://github.com/github-tools/github-release-notes/issues/11)
-- [**enhancement**] Use the issues as data source [#10](https://github.com/github-tools/github-release-notes/issues/10)
-- [**enhancement**] Get the information from the local git config [#9](https://github.com/github-tools/github-release-notes/issues/9)
-- [**enhancement**] Add the possibility to create a CHANGELOG file [#7](https://github.com/github-tools/github-release-notes/issues/7)
-
-
-
- --- 
-
-## 0.4.0 (03/03/2016)
-
-- [**enhancement**] Include various types of commit messages [#5](https://github.com/github-tools/github-release-notes/issues/5)
-
-
-
- --- 
-
-## 0.3.3 (26/01/2016)
-
+## v0.3.3 (14/03/2017)
 *No changelog for this release.*
 
+---
 
+## v0.5.0 (14/03/2017)
 
- --- 
+#### Framework Enhancements:
 
-## 0.3.2 (07/12/2015)
+- [#20](https://github.com/github-tools/github-release-notes/issues/20) Specify which tag to build
+- [#18](https://github.com/github-tools/github-release-notes/issues/18) Create global version of the module
+- [#16](https://github.com/github-tools/github-release-notes/issues/16) Update the documentation
+- [#14](https://github.com/github-tools/github-release-notes/issues/14) Add the chance to override the latest release body
+- [#13](https://github.com/github-tools/github-release-notes/issues/13) Check the network
+- [#11](https://github.com/github-tools/github-release-notes/issues/11) Add tests
+- [#10](https://github.com/github-tools/github-release-notes/issues/10) Use the issues as data source
+- [#9](https://github.com/github-tools/github-release-notes/issues/9) Get the information from the local git config
+- [#7](https://github.com/github-tools/github-release-notes/issues/7) Add the possibility to create a CHANGELOG file
 
+#### Bug Fixes:
+
+- [#15](https://github.com/github-tools/github-release-notes/issues/15) Manage the scenario where there is only one tag
+
+---
+
+## v0.6.1 (14/03/2017)
+
+#### Framework Enhancements:
+
+- [#39](https://github.com/github-tools/github-release-notes/issues/39) Use different files type for configuration
+
+#### Bug Fixes:
+
+- [#43](https://github.com/github-tools/github-release-notes/issues/43) Error when there is only one tag
+
+---
+
+## v0.6.2 (14/03/2017)
+
+#### Bug Fixes:
+
+- [#45](https://github.com/github-tools/github-release-notes/issues/45) Remove unused option user.name
+
+---
+
+## v0.6.3 (14/03/2017)
+
+#### Bug Fixes:
+
+- [#48](https://github.com/github-tools/github-release-notes/issues/48) Fix multiple repo information
+
+---
+
+## v0.4.0 (14/03/2017)
+
+#### Framework Enhancements:
+
+- [#5](https://github.com/github-tools/github-release-notes/issues/5) Include various types of commit messages
+
+---
+
+## v0.6.0 (14/03/2017)
+
+#### Framework Enhancements:
+
+- [#32](https://github.com/github-tools/github-release-notes/issues/32) Unwrap github-api promises
+- [#26](https://github.com/github-tools/github-release-notes/issues/26) Use external config file
+- [#23](https://github.com/github-tools/github-release-notes/issues/23) Introduce templates for the issues
+- [#19](https://github.com/github-tools/github-release-notes/issues/19) Add an "ignore label" flag
+- [#12](https://github.com/github-tools/github-release-notes/issues/12) Add the chance to rebuild the history of release notes
+
+#### Bug Fixes:
+
+- [#29](https://github.com/github-tools/github-release-notes/issues/29) Remove escaping character on regex
+- [#24](https://github.com/github-tools/github-release-notes/issues/24) The changelog action doesn't compile latest release
+
+---
+
+## v0.2.2 (10/03/2017)
 *No changelog for this release.*
 
+---
 
-
- --- 
-
-## 0.3.1 (07/12/2015)
-
+## v0.3.0 (10/03/2017)
 *No changelog for this release.*
 
+---
 
-
- --- 
-
-## 0.3.0 (19/11/2015)
-
+## v0.3.1 (10/03/2017)
 *No changelog for this release.*
 
+---
 
-
- --- 
-
-## 0.2.2 (18/11/2015)
-
+## v0.3.2 (10/03/2017)
 *No changelog for this release.*
 
+---
 
-
- --- 
-
-## 0.2.1 (18/11/2015)
-
+## v0.2.1 (26/09/2016)
 *No changelog for this release.*
 
+---
 
+## v0.2.0 (26/09/2016)
 
- --- 
+#### Framework Enhancements:
 
-## 0.2.0 (15/11/2015)
+- [#3](https://github.com/github-tools/github-release-notes/issues/3) Cleanse option
 
-- [**enhancement**] Cleanse option [#3](https://github.com/github-tools/github-release-notes/issues/3)
-
-
-
- --- 
+---
 
 ## v0.1.0 (12/11/2015)
-
 _No changelog for this release._
-
-
- --- 
-

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -88,7 +88,7 @@ You can group the issues in the release notes. So far the only way to group them
 An issue with no label will be included using the template option `no-label` (default "_closed_") as group name.
 To list all the issues that have any other label, use `"..."` as label name.
 
-```json
+```javascript
 {
     "groupBy": {
         "Bug fixes:": ["bug"],
@@ -99,15 +99,15 @@ To list all the issues that have any other label, use `"..."` as label name.
 
 ### Changelog
 
-There different ways to generate the changelog:
+The `changelog` action will generate a `CHANGELOG.md` file where you run the script. The content of the file will be generated in different ways, depending of the options you provide:
 
-1. Get last release notes from github and prepend them to the `CHANGELOG.md` file.
+1. Get release notes from github releases, which you might have generated with this tool or not. _N.B. if the file exists already the script **won't** override it, unless you use the flag `--override`_ 
 ```shell
 gren --action=changelog
 ```
-2. Use all release notes from github and prepend them to the `CHANGELOG.md` file.
+2. Generate the release notes independently using the `gren` script. This will allows you to use all the [options]({{ "options#global-options" | relative_url }}) that the release script uses.
 ```shell
-gren --action=changelog --time-wrap=history
+gren --action=changelog --generate --tags=all
 ```
 3. Override existing release notes and generate new ones from the task and replace the `CHANGELOG.md` file.
 ```shell
@@ -116,7 +116,7 @@ gren --action=changelog --time-wrap=history --override
 
 You can also change the filename with the option `--changelog-filename`. For a complete reference, check the [options]({{ "options#changelog-options" | relative_url }}).
 
-The changelog will look like this:
+The changelog will look like this (depending of your template configuration):
 
 > # Changelog
 ##  v0.4.3 (02/03/2016)

--- a/docs/options.md
+++ b/docs/options.md
@@ -7,7 +7,7 @@ title: Options
 # Options
 
 Below all the options for github-release-notes.
-You can find [Global options](#global-options), [Options for the release action](#release-options) and [Options for the changelog action](#changelog-options)
+You can find [Global options](#global-options), [Options for the release action](#release-options) and [Options for the changelog action](#changelog-options).
 
 To use an option in your terminal, prefix it with `--` _(e.g. `gren --data-source=commits`)_
 To pass it to the `GithubReleaseNotes` class, in the [configuration file](#configuration-file) or in the [grunt task](https://github.com/github-tools/grunt-github-release-notes), they need to be `camelCase`.
@@ -19,12 +19,14 @@ To pass it to the `GithubReleaseNotes` class, in the [configuration file](#confi
 | `username` | **Required** | The username of the repo _e.g. `github-tools`_ | `null` |
 | `repo` | **Required** | The repository name _e.g. `github-release-notes`_ | `null` |
 | `action`| `release` `changelog` | The **gren** action to run. _(see details below for changelog generator)_ | `release` |
+| `tags`    |   `0.1.0` `0.2.0,0.1.0` `all` |   A specific tag or the range of tags to build the release notes from. You can also specify `all` to write all releases. _(To override  existing releases use the --override flag)_ | `false` |
 | `ignore-labels` | `wont_fix` `wont_fix,duplicate` | Ignore the specified labels. | `false` |
 | `ignore-issues-with` | `wont_fix` `wont_fix,duplicate` | Ignore issues that contains one of the specified labels. | `false` |
 | `data-source` | `issues` `commits` | The informations you want to use to build release notes. | `issues` |
 | `prefix` | **String** `e.g. v` | Add a prefix to the tag version. | `null` |
 | `override` | **Flag** | Override the release notes if existing. | `false` |
 | `include-messages` | `merge` `commits` `all` | Filter the messages added to the release notes. _Only used when `data-source` used is `commits` | `commits` |
+| `group-by` | `label` `{...}` | Group the issues using the labels as group headings. You can set custom headings for groups of labels. [See example]({{ "example#group-by" | relative_url }}) | `false` |
 
 ### Release options
 
@@ -32,14 +34,12 @@ To pass it to the `GithubReleaseNotes` class, in the [configuration file](#confi
 | ------- | ------- | ----------- | ------- |
 | `draft` | **Flag** | Set the release as a draft. | `false` |
 | `prerelease` | **Flag** | To set the release as a prerelease. | `false` |
-| `tags`    |   `0.1.0` `0.2.0,0.1.0` `all` |   A specific tag or the range of tags to build the release notes from. You can also specify `all` to write all releases. _(To override  existing releases use the --override flag)_ | `false` |
-| `group-by` | `label` `{...}` | Group the issues using the labels as group headings. You can set custom headings for groups of labels. [See example]({{ "example#group-by" | relative_url }}) | `false` |
 
 ### Changelog options
 
 | Command | Options | Description | Default |
 | ------- | ------- | ----------- | ------- |
-| `time-wrap` | `latest` `history` | The release notes you want to include in the changelog. | `latest` |
+| `generate` | **Flag** | Generate the changelog with GithubReleaseNotes rather then using the repo releases | `false` |
 | `changelog-filename` | **String**, like `changelog.md` | The name of the changelog file. | `CHANGELOG.md` |
 
 ---
@@ -81,9 +81,12 @@ You can configure the output of **gren** using templates. Set your own configura
         "issue": "- {{labels}} {{name}} [{{text}}]({{url}})",
         "label": "[**{{label}}**]",
         "noLabel": "closed",
-        "release": "## {{release}} {{date}}",
-        "group": "#### {{heading}}\n"
+        "group": "\n#### {{heading}}\n",
+        "changelogTitle": "# Changelog\n\n",
+        "release": "## {{release}} {{date}}\n{{body}}",
+        "releaseSeparator": "\n---\n\n"
     }
+
 }
 ```
 {% endraw %}

--- a/src/templates.json
+++ b/src/templates.json
@@ -3,6 +3,8 @@
     "issue": "- {{labels}} {{name}} [{{text}}]({{url}})",
     "label": "[**{{label}}**]",
     "noLabel": "closed",
-    "release": "## {{release}} {{date}}",
-    "group": "#### {{heading}}\n"
+    "group": "\n#### {{heading}}\n",
+    "changelogTitle": "# Changelog\n\n",
+    "release": "## {{release}} ({{date}})\n{{body}}",
+    "releaseSeparator": "\n---\n\n"
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -241,5 +241,6 @@ module.exports = {
     isInRange: isInRange,
     convertStringToArray: convertStringToArray,
     formatDate: formatDate,
-    getConfigFromFile: getConfigFromFile
+    getConfigFromFile: getConfigFromFile,
+    noop: function() {}
 };


### PR DESCRIPTION
Closes #61 

The changelog function gets all the releases in the `CHANGELOG.md` file and now uses the release code to print out releases from scratch when it needs to override it.