### PR TITLE
Update the commit template to receive more options

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -52,16 +52,15 @@ You can configure the output of **gren** using templates. Set your own configura
 ```json
 {
     "template": {
-        "commit": "- {{message}}",
+        "commit": "- [{{message}}]({{url}}) - @{{author}}",
         "issue": "- {{labels}} {{name}} [{{text}}]({{url}})",
         "label": "[**{{label}}**]",
         "noLabel": "closed",
         "group": "\n#### {{heading}}\n",
         "changelogTitle": "# Changelog\n\n",
-        "release": "## {{release}} {{date}}\n{{body}}",
+        "release": "## {{release}} ({{date}})\n{{body}}",
         "releaseSeparator": "\n---\n\n"
     }
-
 }
 ```
 {% endraw %}

--- a/lib/_examples.js
+++ b/lib/_examples.js
@@ -90,6 +90,11 @@ module.exports = {
         {
             description: 'Otherwise, you can just filter the issues that belong to _a_ milestone',
             code: 'gren release --only-milestones'
+        },
+        {
+            name: 'Use commit messages',
+            description: 'Generate release notes based on commit messages',
+            code: 'gren release --data-source=commits'
         }
     ],
     changelog: [

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -370,13 +370,13 @@ class Gren {
      * @since 0.1.0
      * @private
      *
-     * @param  {string} message
+     * @param  {Object} commit
      *
      * @return {string}
      */
-    _templateCommits(message) {
+    _templateCommits({ commit: { message } }) {
         return generate({
-            message: message
+            message
         }, this.options.template.commit);
     }
 
@@ -470,64 +470,65 @@ class Gren {
     }
 
     /**
+     * Filter a commit based on the includeMessages option and commit message
+     *
+     * @since  0.10.0
+     * @private
+     *
+     * @param  {Object} commit
+     *
+     * @return {Boolean}
+     */
+    _filterCommit(commit) {
+        const { commit: { message } } = commit;
+        const messageType = this.options.includeMessages;
+        const filterMap = {
+            merges: function(message) {
+                return message.match(/^merge/i);
+            },
+            commits: function(message) {
+                return !message.match(/^merge/i);
+            },
+            all: function() {
+                return true;
+            }
+        };
+
+        if (filterMap[messageType]) {
+            return filterMap[messageType](message);
+        }
+
+        return filterMap.commits(message);
+    }
+
+    /**
      * Return a commit messages generated body
      *
      * @since 0.1.0
      * @private
      *
-     * @param  {Array} messages
+     * @param  {Array} commits
      *
      * @return {string}
      */
-    _generateCommitsBody(messages = []) {
-        const bodyMessages = Array.from(messages);
+    _generateCommitsBody(commits = []) {
+        const bodyMessages = Array.from(commits);
 
         if (bodyMessages.length === 1) {
             bodyMessages.push(null);
         }
 
+        console.log(bodyMessages
+            .slice(0, -1)
+            .filter(this._filterCommit.bind(this))
+            .map(this._templateCommits.bind(this))
+            .join('\n'));
+
         return bodyMessages
             .slice(0, -1)
-            .filter(message => {
-                const messageType = this.options.includeMessages;
-                const filterMap = {
-                    merges: function(message) {
-                        return message.match(/^merge/i);
-                    },
-                    commits: function(message) {
-                        return !message.match(/^merge/i);
-                    },
-                    all: function() {
-                        return true;
-                    }
-                };
-
-                if (filterMap[messageType]) {
-                    return filterMap[messageType](message);
-                }
-
-                return filterMap.commits(message);
-            })
+            .filter(this._filterCommit.bind(this))
             .map(this._templateCommits.bind(this))
             .join('\n');
-    }
-
-    /**
-     * Transforms the commits to commit messages
-     *
-     * @since 0.1.0
-     * @private
-     *
-     * @param  {Object[]} commits The array of object containing the commits
-     *
-     * @return {String[]}
-     */
-    _commitMessages(commits = []) {
-        if (!Array.isArray(commits)) {
-            return [];
-        }
-
-        return commits.map(({ commit }) => commit && commit.message).filter(Boolean);
     }
 
     /**
@@ -551,7 +552,7 @@ class Gren {
         };
 
         return this.repo.listCommits(options)
-            .then(response => this._commitMessages(response.data));
+            .then(({ data }) => data);
     }
 
     /**

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -374,9 +374,12 @@ class Gren {
      *
      * @return {string}
      */
-    _templateCommits({ commit: { message } }) {
+    _templateCommits({ sha, commit: { author: { name }, message, url } }) {
         return generate({
-            message
+            sha,
+            message: message.split('\n')[0],
+            url,
+            author: name
         }, this.options.template.commit);
     }
 
@@ -479,8 +482,7 @@ class Gren {
      *
      * @return {Boolean}
      */
-    _filterCommit(commit) {
-        const { commit: { message } } = commit;
+    _filterCommit({ commit: { message } }) {
         const messageType = this.options.includeMessages;
         const filterMap = {
             merges: function(message) {
@@ -517,12 +519,6 @@ class Gren {
         if (bodyMessages.length === 1) {
             bodyMessages.push(null);
         }
-
-        console.log(bodyMessages
-            .slice(0, -1)
-            .filter(this._filterCommit.bind(this))
-            .map(this._templateCommits.bind(this))
-            .join('\n'));
 
         return bodyMessages
             .slice(0, -1)

--- a/lib/src/templates.json
+++ b/lib/src/templates.json
@@ -1,5 +1,5 @@
 {
-    "commit": "- {{message}}",
+    "commit": "- [{{message}}]({{url}}) - @{{author}}",
     "issue": "- {{labels}} {{name}} [{{text}}]({{url}})",
     "label": "[**{{label}}**]",
     "noLabel": "closed",

--- a/test/Gren.spec.js
+++ b/test/Gren.spec.js
@@ -267,31 +267,31 @@ describe('Gren', () => {
         });
     });
 
-    describe('_commitMessages', () => {
-        it('Should return an Array of strings', () => {
-            assert.isArray(gren._commitMessages([{ commit: { message: 'First body' }}, { commit: {message: 'Second body' }}]), 'Passing the Array of commits');
-            assert.deepEqual(gren._commitMessages([{ commit: { message: 'First body' }}, { commit: {message: 'Second body' }}]), ['First body', 'Second body'], 'Passing the Array of commits');
-        });
-
-        it('Should return an empty Array', () => {
-            assert.deepEqual(gren._commitMessages([]), [], 'Passing empty Array');
-            assert.deepEqual(gren._commitMessages([1, 2, 3]), [], 'Passing invalid Array');
-            assert.deepEqual(gren._commitMessages(false), [], 'Passing false');
-            assert.deepEqual(gren._commitMessages(true), [], 'Passing true');
-            assert.deepEqual(gren._commitMessages(), [], 'No parameters');
-            assert.deepEqual(gren._commitMessages('string'), [], 'Passing a string');
-        });
-    });
-
-    describe('_generateCommitsBody, _templateCommits', () => {
+    describe('_generateCommitsBody, _templateCommits, _filterCommit', () => {
         let commitMessages;
 
         before(() => {
             commitMessages = [
-                "First commit",
-                "This is another commit",
-                "Merge branch into master: Something else here to be tested",
-                "This is the last one"
+                {
+                    commit: {
+                        message: "First commit"
+                    }
+                },
+                {
+                    commit: {
+                        message: "This is another commit"
+                    }
+                },
+                {
+                    commit: {
+                        message: "Merge branch into master: Something else here to be tested"
+                    }
+                },
+                {
+                    commit: {
+                        message: "This is the last one"
+                    }
+                }
             ];
 
             // This makes the test easier
@@ -308,20 +308,20 @@ describe('Gren', () => {
 
         it('Should not return the last message', () => {
             assert.notInclude(gren._generateCommitsBody(commitMessages), commitMessages.slice(-1)[0], 'Generate the messages');
-            assert.deepEqual(gren._generateCommitsBody(['One message']), 'One message', 'One message passed');
-            assert.deepEqual(gren._generateCommitsBody(['One', 'Two']), 'One', 'Two message passed');
-            assert.deepEqual(gren._generateCommitsBody(['One', 'Two', 'Three']), 'One\nTwo', 'Three message passed');
+            assert.deepEqual(gren._generateCommitsBody([{ commit: { message: 'One message' }}]), 'One message', 'One message passed');
+            assert.deepEqual(gren._generateCommitsBody([{ commit: { message: 'One' }}, { commit: { message: 'Two' }}]), 'One', 'Two message passed');
+            assert.deepEqual(gren._generateCommitsBody([{ commit: { message: 'One' }}, { commit: { message: 'Two' }}, { commit: { message: 'Three' }}]), 'One\nTwo', 'Three message passed');
         });
 
         it('Should only return the messages defined in the options', () => {
             gren.options.includeMessages = 'commits';
-            assert.deepEqual(gren._generateCommitsBody(commitMessages), `${commitMessages[0]}\n${commitMessages[1]}`, 'Using commits as includeMessages');
+            assert.deepEqual(gren._generateCommitsBody(commitMessages), `${commitMessages[0].commit.message}\n${commitMessages[1].commit.message}`, 'Using commits as includeMessages');
 
             gren.options.includeMessages = 'all';
-            assert.deepEqual(gren._generateCommitsBody(commitMessages), `${commitMessages[0]}\n${commitMessages[1]}\n${commitMessages[2]}`, 'Using commits as includeMessages');
+            assert.deepEqual(gren._generateCommitsBody(commitMessages), `${commitMessages[0].commit.message}\n${commitMessages[1].commit.message}\n${commitMessages[2].commit.message}`, 'Using commits as includeMessages');
 
             gren.options.includeMessages = 'merges';
-            assert.deepEqual(gren._generateCommitsBody(commitMessages), commitMessages[2], 'Using commits as includeMessages');
+            assert.deepEqual(gren._generateCommitsBody(commitMessages), commitMessages[2].commit.message, 'Using commits as includeMessages');
         });
     });
 

--- a/test/Gren.spec.js
+++ b/test/Gren.spec.js
@@ -271,31 +271,42 @@ describe('Gren', () => {
         let commitMessages;
 
         before(() => {
+            gren.options.template.commit = '{{message}} - {{author}}';
+
             commitMessages = [
                 {
                     commit: {
-                        message: "First commit"
+                        message: 'First commit',
+                        author: {
+                            name: 'alexcanessa'
+                        }
                     }
                 },
                 {
                     commit: {
-                        message: "This is another commit"
+                        message: 'This is another commit',
+                        author: {
+                            name: 'alexcanessa'
+                        }
                     }
                 },
                 {
                     commit: {
-                        message: "Merge branch into master: Something else here to be tested"
+                        message: 'Merge branch into master: Something else here to be tested',
+                        author: {
+                            name: 'alexcanessa'
+                        }
                     }
                 },
                 {
                     commit: {
-                        message: "This is the last one"
+                        message: 'This is the last one',
+                        author: {
+                            name: 'alexcanessa'
+                        }
                     }
                 }
             ];
-
-            // This makes the test easier
-            gren.options.template.commit = '{{message}}';
         });
 
         it('Should always return a string', () => {
@@ -307,21 +318,71 @@ describe('Gren', () => {
         });
 
         it('Should not return the last message', () => {
-            assert.notInclude(gren._generateCommitsBody(commitMessages), commitMessages.slice(-1)[0], 'Generate the messages');
-            assert.deepEqual(gren._generateCommitsBody([{ commit: { message: 'One message' }}]), 'One message', 'One message passed');
-            assert.deepEqual(gren._generateCommitsBody([{ commit: { message: 'One' }}, { commit: { message: 'Two' }}]), 'One', 'Two message passed');
-            assert.deepEqual(gren._generateCommitsBody([{ commit: { message: 'One' }}, { commit: { message: 'Two' }}, { commit: { message: 'Three' }}]), 'One\nTwo', 'Three message passed');
+            const lastMessage = commitMessages.slice(-1)[0];
+
+            assert.notInclude(gren._generateCommitsBody(commitMessages), `${lastMessage.commit.message} - ${lastMessage.commit.author.name}`, 'Generate the messages');
+            assert.deepEqual(gren._generateCommitsBody([{
+                commit: {
+                    message: 'One message',
+                    author: {
+                        name: 'alexcanessa'
+                    }
+                }
+            }]), 'One message - alexcanessa', 'One message passed');
+            assert.deepEqual(gren._generateCommitsBody([{
+                commit: {
+                    message: 'One',
+                    author: {
+                        name: 'alexcanessa'
+                    }
+                }
+            },
+            {
+                commit: {
+                    message: 'Two',
+                    author: {
+                        name: 'alexcanessa'
+                    }
+                }
+            }]), 'One - alexcanessa', 'Two message passed');
+            assert.deepEqual(gren._generateCommitsBody([{
+                commit: {
+                    message: 'One',
+                    author: {
+                        name: 'alexcanessa'
+                    }
+                }
+            },
+            {
+                commit: {
+                    message: 'Two',
+                    author: {
+                        name: 'alexcanessa'
+                    }
+                }
+            },
+            {
+                commit: {
+                    message: 'Three',
+                    author: {
+                        name: 'alexcanessa'
+                    }
+                }
+            }]), 'One - alexcanessa\nTwo - alexcanessa', 'Three message passed');
         });
 
         it('Should only return the messages defined in the options', () => {
             gren.options.includeMessages = 'commits';
-            assert.deepEqual(gren._generateCommitsBody(commitMessages), `${commitMessages[0].commit.message}\n${commitMessages[1].commit.message}`, 'Using commits as includeMessages');
+
+            const messages = msg => `${commitMessages[msg].commit.message} - ${commitMessages[msg].commit.author.name}`;
+
+            assert.deepEqual(gren._generateCommitsBody(commitMessages), `${messages(0)}\n${messages(1)}`, 'Using commits as includeMessages');
 
             gren.options.includeMessages = 'all';
-            assert.deepEqual(gren._generateCommitsBody(commitMessages), `${commitMessages[0].commit.message}\n${commitMessages[1].commit.message}\n${commitMessages[2].commit.message}`, 'Using commits as includeMessages');
+            assert.deepEqual(gren._generateCommitsBody(commitMessages), `${messages(0)}\n${messages(1)}\n${messages(2)}`, 'Using commits as includeMessages');
 
             gren.options.includeMessages = 'merges';
-            assert.deepEqual(gren._generateCommitsBody(commitMessages), commitMessages[2].commit.message, 'Using commits as includeMessages');
+            assert.deepEqual(gren._generateCommitsBody(commitMessages), messages(2), 'Using commits as includeMessages');
         });
     });
 


### PR DESCRIPTION
The commit message was the only template that didn't have many options.

### Now the commit can use these options:

- `author`
- `sha`
- `url`
- `message`

### The options are:

1. Via string in the `.grenrc.json` file

```
{
    template: {
        "commit": "- [{{message}}]({{url}}) - @{{author}}"
    }
}
```

2. Via function in the `.grenrc.js` file

```
module.exports = {
    template: {
        commit: ({ author, url, message}) => `- @${author}: [${message}](${url})`)
}
```

resolves #72 

