### PR TITLE
Remove the limit option and add the logic to tags all and pagination

### DIFF
--- a/lib/_examples.js
+++ b/lib/_examples.js
@@ -70,17 +70,17 @@ module.exports = {
         },
         {
             name: 'Create release notes for a specific tag',
-            description: 'Get the commits or issues closed between the specified tag and the one before.',
+            description: 'Create release notes from the commits or issues closed for the specified tag and the one before.',
             code: 'gren release --tags=4.0.0'
         },
         {
-            description: 'Get the commits or the issues between two specified tags.',
+            description: 'Create release notes from the commits or the issues between two specified tags.',
             code: 'gren release --tags=4.0.0..3.0.0'
         },
         {
             name: 'Create release notes for all the tags',
-            description: 'Get the commits or issues closed between the specified tag and the one before.',
-            code: 'gren release --tags=all --limit=200'
+            description: 'Create release notes for all the tags in the repository.',
+            code: 'gren release --tags=all'
         },
         {
             name: 'Work with milestones',

--- a/lib/_options.js
+++ b/lib/_options.js
@@ -59,15 +59,8 @@ module.exports = {
             short: '-t',
             name: 'tags',
             valueType: '<new-tag>..<old-tag>',
-            description: 'Write release notes for <new-tag> using data collected until <old-tag>. If only one tag is specified, will use data until the previous tag. To run gren for all the tags, use --tags=*',
+            description: 'Write release notes for <new-tag> using data collected until <old-tag>. If only one tag is specified, will use data until the previous tag. To run gren for all the tags, use --tags=all',
             action: value => value.split('..')
-        },
-        {
-            short: '-l',
-            name: 'limit',
-            valueType: '<number>',
-            description: 'The limit of tags/releases to get. [30]',
-            defaultValue: '30'
         },
         {
             short: '-D',

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -17,9 +17,11 @@ const defaults = {
     ignoreLabels: false,
     ignoreIssuesWith: false,
     groupBy: false,
-    limit: 30,
     milestoneMatch: 'Release {{tag_name}}'
 };
+
+const MAX_TAGS_LIMIT = 99;
+const TAGS_LIMIT = 30;
 
 /** Class creating release notes and changelog notes */
 class Gren {
@@ -32,6 +34,7 @@ class Gren {
         this.options.tags = utils.convertStringToArray(tags);
         this.options.ignoreLabels = utils.convertStringToArray(ignoreLabels);
         this.options.ignoreIssuesWith = utils.convertStringToArray(ignoreIssuesWith);
+        this.options.limit = this.options.tags.indexOf('all') >= 0 ? MAX_TAGS_LIMIT : TAGS_LIMIT;
 
         if (!token) {
             throw chalk.red('You must provide the TOKEN');
@@ -58,7 +61,11 @@ class Gren {
 
         return this._hasNetwork()
             .then(this._getReleaseBlocks.bind(this))
-            .then(blocks => blocks.reduce((carry, block) => carry.then(this._prepareRelease.bind(this, block)), Promise.resolve()));
+            .then(blocks => {
+                console.log('');
+
+                return blocks.reduce((carry, block) => carry.then(this._prepareRelease.bind(this, block)), Promise.resolve());
+            });
     }
 
     /**
@@ -278,17 +285,17 @@ class Gren {
      * @since 0.1.0
      * @private
      *
+     * @param {Array} releases
+     * @param {number} page
+     *
      * @return {Promise}
      */
-    _getLastTags(releases) {
-        const loaded = utils.task(this, 'Getting tags');
-
+    _getLastTags(releases, page = 1, limit = this.options.limit) {
         return this._listTags({
-            per_page: this.options.limit
+            per_page: limit,
+            page
         })
-            .then(({ data: tags }) => {
-                loaded();
-
+            .then(({ headers: { link }, data: tags }) => {
                 if (!tags.length) {
                     throw chalk.red('Looks like you have no tags! Tag a commit first and then run gren again');
                 }
@@ -304,8 +311,11 @@ class Gren {
                             releaseId: releaseId
                         };
                     });
+                const totalPages = this._getLastPage(link);
 
-                console.log('Tags found: ' + filteredTags.map(tag => tag.tag.name).join(', '));
+                if (this.options.tags.indexOf('all') >= 0 && totalPages && +page < totalPages) {
+                    return this._getLastTags(releases, page + 1).then(moreTags => moreTags.concat(filteredTags));
+                }
 
                 return filteredTags;
             });
@@ -323,10 +333,10 @@ class Gren {
      */
     _getTagDates(tags) {
         return tags.map(tag => this.repo.getCommit(tag.tag.commit.sha)
-            .then(response => ({
+            .then(({ data: { committer } }) => ({
                 id: tag.releaseId,
                 name: tag.tag.name,
-                date: response.data.committer.date
+                date: committer.date
             })));
     }
 
@@ -343,6 +353,22 @@ class Gren {
     }
 
     /**
+     * Get the last page from a Hypermedia link
+     *
+     * @since  0.11.1
+     * @private
+     *
+     * @param  {string} link
+     *
+     * @return {boolean|number}
+     */
+    _getLastPage(link) {
+        const linkMatch = Boolean(link) && link.match(/page=(\d+)>; rel="last"/);
+
+        return linkMatch && +linkMatch[1];
+    }
+
+    /**
      * Get all releases
      *
      * @since 0.5.0
@@ -350,14 +376,21 @@ class Gren {
      *
      * @return {Promise} The promise which resolves an array of releases
      */
-    _getListReleases() {
+    _getListReleases(page = 1, limit = this.options.limit) {
         const loaded = utils.task(this, 'Getting the list of releases');
 
         return this._listReleases({
-            per_page: this.options.limit
+            per_page: limit,
+            page
         })
-            .then(({ data: releases }) => {
+            .then(({ headers: { link }, data: releases }) => {
                 loaded();
+
+                const totalPages = this._getLastPage(link);
+
+                if (this.options.tags.indexOf('all') >= 0 && totalPages && +page < totalPages) {
+                    return this._getListReleases(page + 1).then(moreReleases => moreReleases.concat(releases));
+                }
 
                 process.stdout.write(releases.length + ' releases found\n');
 
@@ -791,7 +824,7 @@ class Gren {
                         .filter(this._filterBlockIssue.bind(this, range));
                     const body = (!range[0].body || this.options.override) && this._groupBy(filteredIssues);
 
-                    process.stdout.write(filteredIssues.length + ' issues found\n');
+                    process.stdout.write(`${this.options.prefix + range[0].name} has ${filteredIssues.length} issues found\t`);
 
                     return {
                         id: range[0].id,
@@ -861,8 +894,16 @@ class Gren {
         };
 
         return this._getListReleases()
-            .then(releases => this._getLastTags(releases.length ? releases : false))
+            .then(releases => {
+                loaded = utils.task(this, 'Getting tags');
+
+                return this._getLastTags(releases.length ? releases : false);
+            })
             .then(tags => {
+                loaded();
+
+                console.log('Tags found: ' + tags.map(({ tag: { name } }) => name).join(', '));
+
                 loaded = utils.task(this, 'Getting the tag dates ranges');
 
                 return Promise.all(this._getTagDates(tags));

--- a/test/Gren.spec.js
+++ b/test/Gren.spec.js
@@ -7,8 +7,8 @@ import { requireConfig } from '../lib/src/_utils.js';
 const TOKEN = process.env.GREN_GITHUB_TOKEN;
 
 if (!TOKEN) {
-    console.log(chalk.blue('Token not present, skipping Gren tests.'))
-    describe = describe.skip
+    console.log(chalk.blue('Token not present, skipping Gren tests.'));
+    describe = describe.skip;
 }
 
 describe('Gren', () => {
@@ -96,10 +96,10 @@ describe('Gren', () => {
 
             assert.deepEqual(gren._createReleaseRanges(blocks), rangedBlocks, 'Given release blocks');
 
-            gren.options.tags = 'all'
+            gren.options.tags = 'all';
             assert.deepEqual(gren._createReleaseRanges(blocks), rangedBlocks.concat([[
                 {
-                    date: '2016-09-01T23:00:00.000Z',
+                    date: '2016-09-01T23:00:00.000Z'
                 },
                 {
                     id: 0,
@@ -125,6 +125,20 @@ describe('Gren', () => {
                 noMilestone: issueFile.filter(({ id }) => id === 234567891),
                 noLabel: issueFile.filter(({ id }) => id === 234567891)
             };
+        });
+
+        describe('_getLastPage', () => {
+            it('Should return the number of the last page', () => {
+                const link = '<https://api.github.com/search/code?q=addClass+user%3Amozilla&page=2>; rel="next", <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>; rel="last"';
+
+                assert.deepEqual(gren._getLastPage(link), 34, 'String of pages');
+            });
+
+            it('Should return false', () => {
+                assert.isNotOk(gren._getLastPage(), 'Nothing has been passed');
+                assert.isNotOk(gren._getLastPage('Lorem ipsum'), 'The string does not contain the page information');
+                assert.isNotOk(gren._getLastPage(false), 'False has been passed');
+            });
         });
 
         describe('_groupBy, _groupByLabel', () => {
@@ -497,22 +511,22 @@ describe('Gren', () => {
             gren._listReleases({
                 per_page: 10
             })
-            .then(({ data: releases }) => {
-                assert.lengthOf(releases, 10, 'The list of releases is the set one.');
-                done();
-            })
-            .catch(err => done(err));
+                .then(({ data: releases }) => {
+                    assert.lengthOf(releases, 10, 'The list of releases is the set one.');
+                    done();
+                })
+                .catch(err => done(err));
         });
 
         it('_listTags', done => {
             gren._listTags({
                 per_page: 10
             })
-            .then(({ data: tags }) => {
-                assert.lengthOf(tags, 10, 'The list of tags is the set one.');
-                done();
-            })
-            .catch(err => done(err));
+                .then(({ data: tags }) => {
+                    assert.lengthOf(tags, 10, 'The list of tags is the set one.');
+                    done();
+                })
+                .catch(err => done(err));
         });
 
         it('_getReleaseBlocks', done => {


### PR DESCRIPTION
If the option `tags` is `all` the purpose is to get all the tags in the repo, therefore the option `limit` is not necessary.

Resolves #95