### PR TITLE
Fix 132 tags not found

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -312,7 +312,7 @@ class Gren {
             });
         const totalPages = this._getLastPage(link);
 
-        if (this.options.tags.indexOf('all') >= 0 && totalPages && +page < totalPages) {
+        if ((this.options.tags.indexOf('all') >= 0 || filteredTags < 2) && totalPages && +page < totalPages) {
             return this._getLastTags(releases, page + 1).then(moreTags => moreTags.concat(filteredTags));
         }
 

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -904,6 +904,7 @@ class Gren {
         this.tasks['Getting releases'].text = 'Getting tags';
 
         const tags = await this._getLastTags(releases.length ? releases : false);
+        this._validateRequiredTagsExists(tags, this.options.tags);
         const releaseDates = await Promise.all(this._getTagDates(tags));
 
         loaded(`Tags found: ${tags.map(({ tag: { name } }) => name).join(', ')}`);
@@ -911,6 +912,27 @@ class Gren {
         return dataSource[this.options.dataSource](
             this._createReleaseRanges(releaseDates)
         );
+    }
+
+    /**
+     * Check that the require tags are exists in tags
+     *
+     * @param {Array} tags
+     * @param {any} requireTags
+     *
+     * @return{}
+     */
+    _validateRequiredTagsExists(tags, requireTags) {
+        if (tags.indexOf('all') > 0 || !(requireTags instanceof Array)) return;
+
+        const tagsNames = tags.map(x => x.tag.name);
+
+        const missingTags = requireTags.filter(x => tagsNames.indexOf(x) < 0);
+        if (missingTags.length > 0) {
+            const notFoundMessage = (missingTags.length === 1) ? 'tag is' : 'tags are';
+            throw chalk.red(`\nThe following ${notFoundMessage} not found in the repository: ${missingTags}. ` +
+                'please provider tags that are exists in the repository');
+        }
     }
 
     /**

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -929,8 +929,8 @@ class Gren {
 
         const missingTags = requireTags.filter(requireTag => tagsNames.indexOf(requireTag) < 0);
         if (missingTags.length > 0) {
-            const notFoundMessage = (missingTags.length === 1) ? 'tag is' : 'tags are';
-            throw chalk.red(`\nThe following ${notFoundMessage} not found in the repository: ${missingTags}. ` +
+            const inflection = (missingTags.length === 1) ? 'tag is' : 'tags are';
+            throw chalk.red(`\nThe following ${inflection} not found in the repository: ${missingTags}. ` +
                 'please provide existing tags.');
         }
     }

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -923,7 +923,7 @@ class Gren {
      * @return{}
      */
     _validateRequiredTagsExists(tags, requireTags) {
-        if (tags.indexOf('all') > 0 || !(requireTags instanceof Array)) return;
+        if (requireTags.indexOf('all') >= 0 || !(requireTags instanceof Array)) return;
 
         const tagsNames = tags.map(x => x.tag.name);
 

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -925,9 +925,9 @@ class Gren {
     _validateRequiredTagsExists(tags, requireTags) {
         if (requireTags.indexOf('all') >= 0 || !(requireTags instanceof Array)) return;
 
-        const tagsNames = tags.map(x => x.tag.name);
+        const tagsNames = tags.map(tagData => tagData.tag.name);
 
-        const missingTags = requireTags.filter(x => tagsNames.indexOf(x) < 0);
+        const missingTags = requireTags.filter(requireTag => tagsNames.indexOf(requireTag) < 0);
         if (missingTags.length > 0) {
             const notFoundMessage = (missingTags.length === 1) ? 'tag is' : 'tags are';
             throw chalk.red(`\nThe following ${notFoundMessage} not found in the repository: ${missingTags}. ` +

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -918,9 +918,10 @@ class Gren {
      * Check that the require tags are exists in tags
      *
      * @param {Array} tags
-     * @param {any} requireTags
+     * @param {Array} requireTags
      *
-     * @return{}
+     * @throws{Exception} Will throw exception in case that
+     * @requireTags were set to 2 specific tags and these tags aren't exists in @tags
      */
     _validateRequiredTagsExists(tags, requireTags) {
         if (requireTags.indexOf('all') >= 0 || !(requireTags instanceof Array)) return;

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -931,7 +931,7 @@ class Gren {
         if (missingTags.length > 0) {
             const notFoundMessage = (missingTags.length === 1) ? 'tag is' : 'tags are';
             throw chalk.red(`\nThe following ${notFoundMessage} not found in the repository: ${missingTags}. ` +
-                'please provider tags that are exists in the repository');
+                'please provide existing tags.');
         }
     }
 

--- a/test/Gren.spec.js
+++ b/test/Gren.spec.js
@@ -543,19 +543,25 @@ describe('Gren', () => {
                 .catch(err => done(err));
         });
 
-        it('_getLastTags', done => {
-            gren.options.ignoreTagsWith = ['11'];
-            gren.options.tags = ['0.12.0', '0.11.0'];
-
-            gren._getLastTags()
-                .then(tags => {
-                    assert.notInclude(tags.map(({ name }) => name), '0.11.0', 'The ignored tag is not present');
-                    done();
-                })
-                .catch(err => done(err));
+        describe('_getLastTags', () => {
+            describe('with tags=all', () => {
+                describe('with ignoreTagsWith', () => {
+                    it('should ignore the specific tag', done => {
+                        gren.options.ignoreTagsWith = ['11'];
+                        gren.options.tags = ['all'];
+                        gren._getLastTags()
+                            .then(tags => {
+                                assert.notInclude(tags.map(({ name }) => name), '0.11.0', 'The ignored tag is not present');
+                                done();
+                            })
+                            .catch(err => done(err));
+                    });
+                });
+            });
         });
 
         it('_getReleaseBlocks', done => {
+            gren.options.tags = ['0.12.0', '0.11.0'];
             gren._getReleaseBlocks()
                 .then(releaseBlocks => {
                     assert.isArray(releaseBlocks, 'The releaseBlocks is an Array');

--- a/test/Gren.spec.js
+++ b/test/Gren.spec.js
@@ -504,6 +504,24 @@ describe('Gren', () => {
                 fs.unlinkSync(gren.options.changelogFilename);
             }
         });
+    })
+
+    describe('_validateRequiredTagsExists', () => {
+        it('should failed if one tag is missing', () => {
+            const existingTagName = 'existing_tag';
+            const existingTag = { tag: { name: existingTagName } };
+            const expectedException = chalk.red('\nThe following tag is not found in the repository: some_tag. please provider tags that are exists in the repository');
+            assert.throw(() => gren._validateRequiredTagsExists([existingTag], ['some_tag', 'existing_tag']), expectedException);
+        });
+
+        it('should failed if the two input tags are missing', () => {
+            const expectedException = chalk.red('\nThe following tags are not found in the repository: some_tag,some_other_tag. please provider tags that are exists in the repository');
+            assert.throw(() => gren._validateRequiredTagsExists([], ['some_tag', 'some_other_tag']), expectedException);
+        });
+
+        it('Should do nothing if requireTags=all', () => {
+            assert.doesNotThrow(() => gren._validateRequiredTagsExists([], 'all'));
+        });
     });
 
     describe('Tests that require network', () => {

--- a/test/Gren.spec.js
+++ b/test/Gren.spec.js
@@ -510,12 +510,12 @@ describe('Gren', () => {
         it('should failed if one tag is missing', () => {
             const existingTagName = 'existing_tag';
             const existingTag = { tag: { name: existingTagName } };
-            const expectedException = chalk.red('\nThe following tag is not found in the repository: some_tag. please provider tags that are exists in the repository');
+            const expectedException = chalk.red('\nThe following tag is not found in the repository: some_tag. please provide existing tags.');
             assert.throw(() => gren._validateRequiredTagsExists([existingTag], ['some_tag', 'existing_tag']), expectedException);
         });
 
         it('should failed if the two input tags are missing', () => {
-            const expectedException = chalk.red('\nThe following tags are not found in the repository: some_tag,some_other_tag. please provider tags that are exists in the repository');
+            const expectedException = chalk.red('\nThe following tags are not found in the repository: some_tag,some_other_tag. please provide existing tags.');
             assert.throw(() => gren._validateRequiredTagsExists([], ['some_tag', 'some_other_tag']), expectedException);
         });
 


### PR DESCRIPTION
Close #132 

The resolution contains two parts: 
1.  Enable pagination when two tags were provided in the tags option
2. Validate that the two tags were found (if they were provided)