### PR TITLE
Add custom --config option

### DIFF
--- a/lib/_options.js
+++ b/lib/_options.js
@@ -159,6 +159,12 @@ module.exports = {
             short: '-q',
             name: 'quiet',
             description: 'Run command without console logs.'
+        },
+        {
+            short: '-c',
+            name: 'config',
+            valueType: '<string>',
+            description: 'Specify a custom config filename'
         }
     ],
     releaseOptions: [

--- a/lib/src/Program.js
+++ b/lib/src/Program.js
@@ -16,7 +16,11 @@ class Program {
             .description(this.description)
             .parse(props.argv);
 
-        this.options = Object.assign({}, getConfigFromFile(props.cwd), this._getOptionsFromObject(this.program, this.defaults));
+        this.options = Object.assign(
+            {},
+            getConfigFromFile(props.cwd, program.config),
+            this._getOptionsFromObject(this.program, this.defaults)
+        );
     }
 
     /**

--- a/lib/src/_utils.js
+++ b/lib/src/_utils.js
@@ -2,6 +2,7 @@ const chalk = require('chalk');
 const fs = require('fs');
 const ora = require('ora');
 const YAML = require('json2yaml');
+const Path = require('path');
 const { js_beautify: beautify } = require('js-beautify');
 require('require-yaml');
 
@@ -191,9 +192,13 @@ function requireConfig(filepath) {
  * @param  {string} path Path where to look for config files
  * @return {Object} The configuration from the first found file or empty object
  */
-function getConfigFromFile(path) {
-    return getFileTypes()
-        .reduce((carry, filename) => carry || requireConfig(path + '/' + filename), false) || {};
+function getConfigFromFile(path, customFilename = null) {
+    if (customFilename) {
+        return requireConfig(Path.join(path, customFilename)) || {};
+    } else {
+        return getFileTypes()
+            .reduce((carry, filename) => carry || requireConfig(Path.join(path, filename)), false) || {};
+    }
 }
 
 /**

--- a/lib/src/_utils.js
+++ b/lib/src/_utils.js
@@ -196,8 +196,7 @@ function getConfigFromFile(path, customFilename = null) {
     if (customFilename) {
         const config = requireConfig(Path.join(path, customFilename));
         if (!config) {
-            console.error(chalk.red(`Could not find custom config file: ${customFilename}`));
-            process.exit(1);
+            throw chalk.red(`Could not find custom config file: ${customFilename}`);
         }
         return config;
     }

--- a/lib/src/_utils.js
+++ b/lib/src/_utils.js
@@ -194,11 +194,16 @@ function requireConfig(filepath) {
  */
 function getConfigFromFile(path, customFilename = null) {
     if (customFilename) {
-        return requireConfig(Path.join(path, customFilename)) || {};
-    } else {
-        return getFileTypes()
-            .reduce((carry, filename) => carry || requireConfig(Path.join(path, filename)), false) || {};
+        const config = requireConfig(Path.join(path, customFilename));
+        if (!config) {
+            console.error(chalk.red(`Could not find custom config file: ${customFilename}`));
+            process.exit(1);
+        }
+        return config;
     }
+
+    return getFileTypes()
+        .reduce((carry, filename) => carry || requireConfig(Path.join(path, filename)), false) || {};
 }
 
 /**

--- a/test/_utils.spec.js
+++ b/test/_utils.spec.js
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import chalk from 'chalk';
 import fs from 'fs';
 import YAML from 'yamljs';
 import * as utils from '../lib/src/_utils';
@@ -158,6 +159,13 @@ describe('_utils.js', () => {
             assert.deepEqual(utils.getConfigFromFile(process.cwd() + '/test/.temp'), fileContent, 'Given the right path');
             assert.deepEqual(utils.getConfigFromFile(process.cwd() + '/test/.temp', '.custom-grenrc'), customFileContent, 'Given a custom path');
             assert.deepEqual(utils.getConfigFromFile(process.cwd() + '/test'), {}, 'Given a path with no config file');
+        });
+
+        it('Should throw on non-existent custom config file', () => {
+            assert.throws(
+                () => utils.getConfigFromFile(process.cwd() + '/test/.temp', '.non-existing-grenrc'),
+                chalk.red('Could not find custom config file: .non-existing-grenrc')
+            );
         });
 
         afterEach(() => {

--- a/test/_utils.spec.js
+++ b/test/_utils.spec.js
@@ -142,18 +142,27 @@ describe('_utils.js', () => {
             b: 2
         };
 
+        const customFilename = process.cwd() + '/test/.temp/.custom-grenrc';
+        const customFileContent = {
+            c: 3,
+            d: 4
+        };
+
         beforeEach(() => {
             fs.writeFileSync(filename, JSON.stringify(fileContent));
+            fs.writeFileSync(customFilename, JSON.stringify(customFileContent));
         });
 
         it('Should always return an Object', () => {
             assert.isOk(typeof utils.getConfigFromFile(process.cwd() + '/test/.temp') === 'object', 'The type is an object');
             assert.deepEqual(utils.getConfigFromFile(process.cwd() + '/test/.temp'), fileContent, 'Given the right path');
+            assert.deepEqual(utils.getConfigFromFile(process.cwd() + '/test/.temp', '.custom-grenrc'), customFileContent, 'Given a custom path');
             assert.deepEqual(utils.getConfigFromFile(process.cwd() + '/test'), {}, 'Given a path with no config file');
         });
 
         afterEach(() => {
             fs.unlinkSync(filename);
+            fs.unlinkSync(customFilename);
         });
     });
 


### PR DESCRIPTION
Closes #152.

Adds a `--config` option to specify a custom configuration file, e.g. 

```
gren release --config=.custom.grenrc.js
```

Note that a plain grenrc file can only contain one `.`, so `--custom=.custom.grenrc` will be parsed incorrectly (see the check [here](https://github.com/github-tools/github-release-notes/blob/618973acbdd63dee5607a6997729f1632a0f9689/lib/src/_utils.js#L178-L182)). I left it alone for now, but if you have a preference for how it should behave, let me know 👋 