### PR TITLE
Pass issue bodies and PR base/head branches into templating method

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -509,7 +509,8 @@ class Gren {
             labels: this._templateLabels(issue),
             name: issue.title,
             text: '#' + issue.number,
-            url: issue.html_url
+            url: issue.html_url,
+            body: issue.body
         }, this.options.template.issue);
     }
 

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -510,7 +510,9 @@ class Gren {
             name: issue.title,
             text: '#' + issue.number,
             url: issue.html_url,
-            body: issue.body
+            body: issue.body,
+            pr_base: issue.base && issue.base.ref,
+            pr_head: issue.head && issue.head.ref
         }, this.options.template.issue);
     }
 


### PR DESCRIPTION
Closes #131, closes #161. 

Since we're using `listPullRequests` for PRs now, we can pull the PR base/head directly from `issue`.

As noted in #161, it would be nice to pass the full object along, at least if the config provides a custom templating function, but I'm keeping the scope small for this.