### PR TITLE
Pull the most recently updated PRs

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -371,17 +371,21 @@ class Gren {
      *
      * @return {Promise[]}     The promises which returns pull requests
      */
-    async _getMergedPullRequests(page = 1, limit = 100) {
+    async _getMergedPullRequests(since, page = 1, limit = 1000) {
         const results = await this.repo.listPullRequests({
             state: 'closed',
+            sort: 'updated',
+            direction: 'desc',
             per_page: limit,
             page
         });
+
         const { headers: { link }, data: prs } = results;
         const totalPages = this._getLastPage(link);
         const filterPrs = prs.filter(pr => pr.merged_at);
-        if (totalPages && +page < totalPages) {
-            return this._getMergedPullRequests(page + 1).then(prsResults => prsResults.concat(filterPrs));
+        if (prs.length > 0 && since < prs[prs.length - 1].updated_at &&
+            totalPages && +page < totalPages) {
+            return this._getMergedPullRequests(since, page + 1).then(prsResults => prsResults.concat(filterPrs));
         }
 
         return filterPrs;
@@ -921,7 +925,9 @@ class Gren {
      */
     async _getPullRequestsBlocks(releaseRanges) {
         const loaded = utils.task(this, `Getting all merged pull requests`);
-        const prs = await this._getMergedPullRequests();
+        const since = releaseRanges[releaseRanges.length - 1][1].date;
+        const prs = await this._getMergedPullRequests(since);
+
         let totalPrs = 0;
         const release = releaseRanges
             .map(range => {


### PR DESCRIPTION
Closes #165.

This sorts by `updated_at` when retrieving PRs and short-circuits if it passes the oldest release range date.