### PR TITLE
PRs with issues data source

### DIFF
--- a/lib/_options.js
+++ b/lib/_options.js
@@ -42,12 +42,6 @@ module.exports = {
             description: 'The repository name e.g. github-release-notes'
         },
         {
-            short: '-R',
-            name: 'issuesRepo',
-            valueType: '<repository name>',
-            description: 'The repository name which holds issues - if those are kept in a separate repo'
-        },
-        {
             short: '-T',
             name: 'token',
             valueType: '<github token>',
@@ -88,10 +82,10 @@ module.exports = {
         {
             short: '-D',
             name: 'data-source',
-            valueType: '<issues|commits|milestones|prs>',
+            valueType: '<issues|commits|milestones|prs|prs-with-issues>',
             description:
                 'The informations you want to use to build release notes. [issues]',
-            action: /^(issues|commits|milestones|prs)$/i,
+            action: /^(issues|commits|milestones|prs|prs-with-issues)$/i,
             defaultValue: 'issues'
         },
         {

--- a/lib/_options.js
+++ b/lib/_options.js
@@ -42,6 +42,12 @@ module.exports = {
             description: 'The repository name e.g. github-release-notes'
         },
         {
+            short: '-R',
+            name: 'issuesRepo',
+            valueType: '<repository name>',
+            description: 'The repository name which holds issues - if those are kept in a separate repo'
+        },
+        {
             short: '-T',
             name: 'token',
             valueType: '<github token>',

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -35,6 +35,7 @@ class Gren {
         const {
             username,
             repo,
+            issuesRepo = repo,
             token,
             apiUrl,
             tags,
@@ -72,7 +73,7 @@ class Gren {
         }, apiUrl);
 
         this.repo = githubApi.getRepo(username, repo);
-        this.issues = githubApi.getIssues(username, repo);
+        this.issues = githubApi.getIssues(username, issuesRepo);
     }
 
     /**

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -980,13 +980,13 @@ class Gren {
         const release = releaseRanges
             .map(range => {
                 const list = prs.filter(this._filterBlockPullRequest.bind(this, range));
-                list.forEach(({ relatedIssues }) => relevantIssues = relevantIssues.concat(relatedIssues || []));
+                list.forEach(({ relatedIssues }) => { relevantIssues = relevantIssues.concat(relatedIssues || []); });
                 loaded(`Pull Requests found: ${list.length}`);
                 return Object.assign({}, range, { list });
             });
 
         const issuesDetails = (await Promise.all(relevantIssues.map(this._getSingleIssue.bind(this))))
-            .reduce((acc, el) => (acc[el.number] = el, acc), {});
+            .reduce((acc, el) => { acc[el.number] = el; return acc; }, {});
 
         return release
             .map(range => {

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -35,7 +35,6 @@ class Gren {
         const {
             username,
             repo,
-            issuesRepo = repo,
             token,
             apiUrl,
             tags,
@@ -68,12 +67,12 @@ class Gren {
             this._outputOptions(this.options);
         }
 
-        const githubApi = new Github({
+        this.githubApi = new Github({
             token
         }, apiUrl);
 
-        this.repo = githubApi.getRepo(username, repo);
-        this.issues = githubApi.getIssues(username, issuesRepo);
+        this.repo = this.githubApi.getRepo(username, repo);
+        this.issues = this.githubApi.getIssues(username, repo);
     }
 
     /**
@@ -730,6 +729,13 @@ class Gren {
         return issues;
     }
 
+    async _getSingleIssue({ user, repo, number }) {
+        const loaded = utils.task(this, `Getting single ${number} issue data`);
+        const { data: issue } = await this.githubApi.getIssues(user, repo).getIssue(number);
+        loaded(`Issue details found: ${issue.number} ${issue.title}`);
+        return issue;
+    }
+
     /**
      * Group the issues based on their first label
      *
@@ -953,6 +959,55 @@ class Gren {
         return release;
     }
 
+    async _getPullRequestWithIssueBlocks(releaseRanges) {
+        const loaded = utils.task(this, `Getting all merged pull requests`);
+        const since = releaseRanges[releaseRanges.length - 1][1].date;
+        let relevantIssues = [];
+
+        const re = new RegExp(`([\\w-]+)/([\\w-]+)/issues/([0-9]+)`, 'gi');
+
+        const prs = (await this._getMergedPullRequests(since))
+            .filter(this._filterPullRequest.bind(this))
+            .map(pr => {
+                const matches = pr.body.match(re);
+                const relatedIssues = matches && matches.map(issue => {
+                    const [user, repo, , number] = issue.split('/');
+                    return { user, repo, number };
+                });
+                return Object.assign({}, pr, { relatedIssues });
+            });
+
+        const release = releaseRanges
+            .map(range => {
+                const list = prs.filter(this._filterBlockPullRequest.bind(this, range));
+                list.forEach(({ relatedIssues }) => relevantIssues = relevantIssues.concat(relatedIssues || []));
+                loaded(`Pull Requests found: ${list.length}`);
+                return Object.assign({}, range, { list });
+            });
+
+        const issuesDetails = (await Promise.all(relevantIssues.map(this._getSingleIssue.bind(this))))
+            .reduce((acc, el) => (acc[el.number] = el, acc), {});
+
+        return release
+            .map(range => {
+                const list = range.list.map(el => el.relatedIssues && el.relatedIssues.length ? el.relatedIssues.map(({ number }) => issuesDetails[number]) : [el]);
+                return Object.assign({}, range, { list: [].concat(...list) });
+            })
+            .map(this._render.bind(this));
+    }
+
+    _render(range) {
+        const body = (!range[0].body || this.options.override) && this._groupBy(range.list);
+
+        return {
+            id: range[0].id,
+            release: range[0].name,
+            name: this.options.prefix + range[0].name,
+            published_at: range[0].date,
+            body: this._templateBody(body, range[0].body)
+        };
+    }
+
     /**
      * Sort releases by dates
      *
@@ -1016,7 +1071,8 @@ class Gren {
             issues: this._getIssueBlocks.bind(this),
             commits: this._getCommitBlocks.bind(this),
             milestones: this._getIssueBlocks.bind(this),
-            prs: this._getPullRequestsBlocks.bind(this)
+            prs: this._getPullRequestsBlocks.bind(this),
+            'prs-with-issues': this._getPullRequestWithIssueBlocks.bind(this)
         };
         const releases = await this._getListReleases();
         this.tasks['Getting releases'].text = 'Getting tags';


### PR DESCRIPTION
**Problem**
Can't fetch PRs with issues based on built-in data sources.
Can't fetch issues from different repos.
Fetching all the issues from repo with over 1000 of them takes much longer, than fetching around 10-30 of them for each release, with separate http requests.

**Solution**
This PR introduces new data source of value `prs-with-issues`. With this data source passed through options, Gren will fetch all the PRs between tags, then go through them and find mentioned issues (not necessarily from the same repo). Then it will fetch details only for those relevant issues.
It will finally render all the issues found + only the PRs with no issues mentioned.