### PR TITLE
Pass user.login and user.html_url into issue templating method

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -517,7 +517,9 @@ class Gren {
             url: issue.html_url,
             body: issue.body,
             pr_base: issue.base && issue.base.ref,
-            pr_head: issue.head && issue.head.ref
+            pr_head: issue.head && issue.head.ref,
+            user_login: issue.user.login,
+            user_url: issue.user.html_url
         }, this.options.template.issue);
     }
 


### PR DESCRIPTION
Closes #201 

This makes `user_login` and `user_url` variables available to the issue template.