### PR TITLE
Allow dot in Github slug

### DIFF
--- a/lib/src/GitHubInfo.js
+++ b/lib/src/GitHubInfo.js
@@ -73,7 +73,7 @@ class GitHubInfo {
     */
     _repo(callback) {
         return this._executeCommand('git config remote.origin.url', repo => {
-            const repoPath = matchAll(/([\w-]+)\/([\w-]+)(\.git)?$/g, repo);
+            const repoPath = matchAll(/([\w-\.]+)\/([\w-\.]+)(\.git)?$/g, repo);
 
             if (!repoPath[1]) {
                 return Promise.reject('No repo found');

--- a/lib/src/GitHubInfo.js
+++ b/lib/src/GitHubInfo.js
@@ -73,7 +73,7 @@ class GitHubInfo {
     */
     _repo(callback) {
         return this._executeCommand('git config remote.origin.url', repo => {
-            const repoPath = matchAll(/([\w-\.]+)\/([\w-\.]+)(\.git)?$/g, repo);
+            const repoPath = matchAll(/([\w-\.]+)\/([\w-\.]+?)(\.git)?$/g, repo);
 
             if (!repoPath[1]) {
                 return Promise.reject('No repo found');


### PR DESCRIPTION
Some repositories contains a dot character in the slug:
* https://github.com/ThoughtWorksInc/Binding.scala