### PR TITLE
Provide commit sha to start history with

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -344,6 +344,7 @@ class Gren {
             return {
                 id: tag.releaseId,
                 name: tag.tag.name,
+                sha: tag.tag.commit.sha,
                 date: committer.date
             };
         });
@@ -633,10 +634,11 @@ class Gren {
      *
      * @return {Promise}      The promise which resolves the [Array] commit messages
      */
-    async _getCommitsBetweenTwo(since, until) {
+    async _getCommitsBetweenTwo(since, until, sha) {
         const options = {
             since: since,
             until: until,
+            sha: sha,
             per_page: 100
         };
 
@@ -662,10 +664,10 @@ class Gren {
         const ranges = await Promise.all(
             releaseRanges
                 .map(async range => {
-                    const [{ date: until }, { date: since }] = range;
+                    const [{ date: until, sha }, { date: since }] = range;
 
                     this.tasks[taskName].text = `Get commits between ${utils.formatDate(new Date(since))} and ${utils.formatDate(new Date(until))}`;
-                    const commits = await this._getCommitsBetweenTwo(since, until);
+                    const commits = await this._getCommitsBetweenTwo(since, until, sha);
 
                     return {
                         id: range[0].id,

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -617,7 +617,6 @@ class Gren {
         }
 
         return bodyMessages
-            .slice(0, -1)
             .filter(this._filterCommit.bind(this))
             .map(this._templateCommits.bind(this))
             .join('\n');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "github-release-notes",
     "version": "0.17.0",
-    "description": "Create a release from a tag and uses issues or commits to creating the release notes. It also can generate a CHANGELOG.md file based on the release notes (or generate a brand new).",
+    "description": "A fork of git+https://github.com/github-tools/github-release-notes.git.",
     "main": "./github-release-notes.js",
     "scripts": {
         "start": "node github-release-notes.js",
@@ -14,7 +14,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/github-tools/github-release-notes.git"
+        "url": "git+https://github.com/masim05/github-release-notes.git"
     },
     "directories": {
         "bin": "./bin",


### PR DESCRIPTION
Closes #206 

Current high level logic of `gren.js release --data-source=commits` is:
 - determine a date range
 - pick commits in master branch within this range
 - create release notes using the commits

As a result, the following workflow is problematic (release notes are empty):
 - create a new release branch from master
 - merge to the release branch new changes
 - tag the release branch
 - generate release notes from the tag
 - merge release to master

One option to fix it is to provide `sha` to start history with. Currently it is not provided so default master is always used.