### PR TITLE
Use closed_at for PR changelog date check

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -885,7 +885,7 @@ class Gren {
         }
 
         return utils.isInRange(
-            Date.parse(pullRequest.merged_at),
+            Date.parse(pullRequest.closed_at),
             Date.parse(range[1].date),
             Date.parse(range[0].date)
         );


### PR DESCRIPTION
Fixes issues #128 and #181 .

It appears GitHub is not consistent on the datetime a PR was closed vs merged at. `closed_at` has always been the same or a second or two later than `merged_at` in my experience with the API. I believe `closed_at` is a more consistent way to gather PRs merged for a given tag when generating release notes.

I'm not confident about this change however. This method looks like it's only used for filtering issues, not PRs. I found no other place we use `merged_at` other than to check if a PR was closed without merging.