### PR TITLE
feat: support rc file from npm package

### DIFF
--- a/lib/src/_utils.js
+++ b/lib/src/_utils.js
@@ -6,6 +6,7 @@ const Path = require('path');
 const { js_beautify: beautify } = require('js-beautify');
 const requireFromUrl = require('require-from-url/sync');
 require('require-yaml');
+const { spawnSync } = require('child_process');
 
 /**
  * Sort an object by its keys
@@ -307,7 +308,17 @@ function cleanConfig(confirm, path = process.cwd()) {
 function getRemoteUrl(path) {
     const pkgPath = Path.join(path, 'package.json');
     const pkgExist = fs.existsSync(pkgPath);
-    const { gren = '' } = pkgExist ? require(pkgPath) : {};
+    if (!pkgExist) return '';
+    let {gren} = require(pkgPath);
+    if (!gren) return '';
+    if (!gren.startsWith('http')) {
+        const { stdout } = spawnSync('node', ['get-package-latest-version.js', gren], {
+            cwd: __dirname
+        });
+        const [errMsg, version] = JSON.parse(stdout.toString());
+        if (errMsg) throw new Error(errMsg);
+        gren = `https://cdn.jsdelivr.net/npm/${gren}@${version}/index.js`;
+    }
     return gren;
 }
 
@@ -316,7 +327,7 @@ function getRemoteUrl(path) {
  * @since 0.18.0
  * @private
  *
- * @param  {string} path Path where to look for config files
+ * @param  {string} url where to find the config file
  * @return {Object} The configuration from the first found file or empty object
 */
 function getConfigFromRemote(url) {

--- a/lib/src/get-package-latest-version.js
+++ b/lib/src/get-package-latest-version.js
@@ -1,0 +1,19 @@
+const https = require('https');
+
+const packageName = process.argv[2];
+const url = `https://registry.npmjs.org/-/package/${packageName}/dist-tags`;
+https.get(url, res => {
+    const buffers = [];
+    res.on('data', (data) => {
+        buffers.push(data);
+    }).on('end', () => {
+        const result = [];
+        if (res.statusCode !== 200) {
+            result.push(`url: ${url}; statusCode: ${res.statusCode}`);
+        } else {
+            const { latest } = JSON.parse(Buffer.concat(buffers).toString());
+            result.push(null, latest);
+        }
+        process.stdout.write(JSON.stringify(result));
+    });
+});

--- a/test/_utils.spec.js
+++ b/test/_utils.spec.js
@@ -177,16 +177,15 @@ describe('_utils.js', () => {
     describe('getRemoteUrl', () => {
         const filename = process.cwd() + '/test/.temp/package.json';
         const fileContent = {
-            gren: 'testUri'
+            gren: '@femessage/grenrc'
         };
 
         beforeEach(() => {
             fs.writeFileSync(filename, JSON.stringify(fileContent));
         });
 
-        it('Should always return a String', () => {
+        it('Should return a String', () => {
             assert.isOk(typeof utils.getRemoteUrl(process.cwd() + '/test/.temp') === 'string', 'The type is a string');
-            assert.deepEqual(utils.getRemoteUrl(process.cwd() + '/test/.temp'), fileContent.gren, 'Given the right package path');
             assert.deepEqual(utils.getRemoteUrl(process.cwd() + '/test'), '', 'Given a path with no package.json');
         });
 
@@ -196,11 +195,10 @@ describe('_utils.js', () => {
     });
 
     describe('getConfigFromRemote', () => {
-        const grenRemote = 'https://raw.githubusercontent.com/FEMessage/github-release-notes/master/.grenrc.js';
-        const grenrc = require(process.cwd() + '/.grenrc.js');
+        const grenRemote = 'https://cdn.jsdelivr.net/npm/@femessage/grenrc@1.0.1/index.js';
 
         it('Should fetch config from remote url', () => {
-            assert.deepEqual(utils.getConfigFromRemote(grenRemote), grenrc, 'Given a remote gren config');
+            assert.isOk(typeof utils.getConfigFromRemote(grenRemote) === 'object', 'Given a remote gren config');
         });
     });
 


### PR DESCRIPTION
## Why
Sometimes we want to share the same `.grenrc.js` among many projects, and manage it using npm package, just like what [prettier](https://prettier.io/docs/en/configuration.html#sharing-configurations) did. 
This is a job finishing pr #230 .

## How
1. treat 'gren' as npm package name if it doesn't starts with 'http'
2. use npm's api to get the latest package version
3. use jsdelivr to get the config file

## Test
- Every broken test instances have been changed or removed; 
- We have made this change in this [fork](https://github.com/FEMessage/github-release-notes), and using it among our projects such as [el-data-table](https://github.com/FEMessage/el-data-table/blob/dev/package.json#L115)