### PR TITLE
Commit dates fix, release body and preview

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -217,10 +217,20 @@ class Gren {
      * @return {Promise}
      */
     _prepareRelease(block) {
+        const { template } = this.options;
+
+        // enable custom content parsing in releaseBody
+        const releaseBody = generate({
+            release: block.name || block.release,
+            date: utils.formatDate(new Date(block.published_at)),
+            isoDate: block.published_at,
+            body: block.body
+        }, template.releaseBody);
+
         const releaseOptions = {
             tag_name: block.release,
             name: block.name,
-            body: block.body,
+            body: releaseBody,
             draft: this.options.draft,
             prerelease: this.options.prerelease
         };
@@ -508,11 +518,19 @@ class Gren {
     _templateReleases(releases) {
         const { template } = this.options;
 
-        return releases.map(release => generate({
-            release: release.name || release.tag_name,
-            date: utils.formatDate(new Date(release.published_at)),
-            body: release.body
-        }, template.release)).join(template.releaseSeparator);
+        return releases.map(release => {
+            const content = {
+                release: release.name || release.tag_name,
+                date: utils.formatDate(new Date(release.published_at)),
+                iso8601Date: release.published_at,
+                body: release.body
+            };
+
+            // enable custom content parsing in releaseBody
+            content.body = generate(content, template.releaseBody);
+
+            return generate(content, template.release);
+        }).join(template.releaseSeparator);
     }
 
     /**

--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -365,6 +365,20 @@ class Gren {
                 };
             });
 
+        // get the commit date for each tag via /repos/.../commits for a single sha each, in parallel
+        // -- the date for filtering PRs/commits/issues needs to be exact to the commit date
+        // could be simplified if Github API endpoint /repos/.../tags would return tag linked commit information...
+        await Promise.all(filteredTags.map((entry, index) => {
+            const options = {
+                sha: entry.tag.commit.sha,
+                per_page: 1,
+                page: 1
+            };
+            return this.repo.listCommits(options).then(({ data: [{commit: {committer: {date}}}] }) => {
+                filteredTags[index].commitDate = date;
+            });
+        }));
+
         const totalPages = this._getLastPage(link);
 
         if (totalPages && page < totalPages) {
@@ -657,7 +671,6 @@ class Gren {
      */
     _generateCommitsBody(commits = [], addEmptyCommit) {
         const bodyMessages = Array.from(commits);
-
         if (bodyMessages.length === 1 || addEmptyCommit) {
             bodyMessages.push(null);
         }
@@ -709,7 +722,7 @@ class Gren {
         const ranges = await Promise.all(
             releaseRanges
                 .map(async range => {
-                    const [{ date: until }, { date: since }] = range;
+                    const [{ commitDate: until }, { commitDate: since }] = range;
 
                     this.tasks[taskName].text = `Get commits between ${utils.formatDate(new Date(since))} and ${utils.formatDate(new Date(until))}`;
                     const commits = await this._getCommitsBetweenTwo(since, until);
@@ -1067,8 +1080,8 @@ class Gren {
      *
      * @return {Array}
      */
-    _sortReleasesByDate(releaseDates) {
-        return Array.from(releaseDates).sort((release1, release2) => new Date(release2.date) - new Date(release1.date));
+    _sortReleasesByTagCommitDate(releaseDates) {
+        return Array.from(releaseDates).sort((release1, release2) => new Date(release2.commitDate) - new Date(release1.commitDate));
     }
 
     /**
@@ -1084,12 +1097,12 @@ class Gren {
     _createReleaseRanges(releaseDates) {
         const ranges = [];
         const RANGE = 2;
-        const sortedReleaseDates = this._sortReleasesByDate(releaseDates);
+        const sortedReleaseDates = this._sortReleasesByTagCommitDate(releaseDates);
 
         if (sortedReleaseDates.length === 1 || this.options.tags.indexOf('all') >= 0) {
             sortedReleaseDates.push({
                 id: 0,
-                date: new Date(0)
+                commitDate: new Date(0)
             });
         }
 
@@ -1129,7 +1142,7 @@ class Gren {
 
         this._validateRequiredTagsExists(tags, this.options.tags);
 
-        const releaseDates = this._sortReleasesByDate(this._transformTagsIntoReleaseObjects(tags));
+        const releaseDates = this._sortReleasesByTagCommitDate(this._transformTagsIntoReleaseObjects(tags));
         const selectedTags = (this._getSelectedTags(releaseDates) || (releaseDates.length > 1 ? [releaseDates[0], releaseDates[1]] : releaseDates));
 
         loaded(`Tags found: ${selectedTags.map(({ name }) => name).join(', ')}`);
@@ -1143,7 +1156,8 @@ class Gren {
         return tags.map(tag => ({
             id: tag.releaseId,
             name: tag.tag.name,
-            date: tag.date
+            date: tag.date,
+            commitDate: tag.commitDate
         }));
     }
 

--- a/lib/src/templates.js
+++ b/lib/src/templates.js
@@ -7,5 +7,6 @@ module.exports = {
     group: '\n#### {{heading}}\n',
     changelogTitle: '# Changelog\n\n',
     release: '## {{release}} ({{date}})\n{{body}}',
-    releaseSeparator: '\n---\n\n'
+    releaseSeparator: '\n---\n\n',
+    releaseBody: '{{body}}'
 };


### PR DESCRIPTION
Base version documentation: https://github.com/github-tools/github-release-notes

**Changes here:**

- Fixed a bug in `gren` where it would source info only via release dates
  - commits dated after the tag but before the release were being picked up
  - commits dated before previous release but ahead of the respective tag were not picked up
- Added the option to parse/add to final ahead

**TO-DO:**: 
- add `--preview` option to the CLI (similar to `--draft` but terminal preview only)

**Running locally:**
- in this repo folder:
- `$ npm install`
- `$ gulp build`
- in target repo folder:
- `$ ../relative-path-to/github-release-notes/bin/gren.js <cli-commands>`

**Custom `.grenrc.js` example**
```javascript
/* .grenrc.js */

module.exports = {
  template: {
    commit: ({ message, url, author, name }) => `- ${message}`,
    noLabel: "closed",
    group: "\n#### {{heading}}\n",
    changelogTitle: "# Changelog\n\n",
    release: "## {{release}} ({{date}})\n{{body}}",
    releaseSeparator: "\n---\n\n",
    releaseBody: ({ isoDate, body }) => {
      const date = new Date(isoDate);
      const dateStr = new Date(date - 8 * 60 * 60 * 1000).toLocaleString("en-US") + ' PST';
      //const dateStr = date.toLocaleString('en-US');
      return `${dateStr}\n${body}`
    },
  },
  ignoreCommitsWith: "^[0-9]+\.[0-9]+\.[0-9]+$",
  dataSource: "commits",
  includeMessages: "commits",
  changelogFilename: "CHANGELOG.md"
}
```