### PR TITLE
Return exit code 1 on error for gren changelog

### DIFF
--- a/lib/gren-changelog.js
+++ b/lib/gren-changelog.js
@@ -32,4 +32,5 @@ changelogCommand.init()
     })
     .catch(error => {
         console.error(error);
+        process.exit(1);
     });


### PR DESCRIPTION
Fixes #222, also fixes #278

Exit code 1 in case of error in gren changelog