### PR TITLE
Correctly compare dates for PR retrieval; fix tests

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -430,7 +430,7 @@ class Gren {
         const { headers: { link }, data: prs } = results;
         const totalPages = this._getLastPage(link);
         const filterPrs = prs.filter(pr => pr.merged_at);
-        if (prs.length > 0 && since < prs[prs.length - 1].updated_at &&
+        if (prs.length > 0 && since < (new Date(prs[prs.length - 1].updated_at)) &&
             totalPages && +page < totalPages) {
             return this._getMergedPullRequests(since, page + 1).then(prsResults => prsResults.concat(filterPrs));
         }

--- a/lib/src/_utils.js
+++ b/lib/src/_utils.js
@@ -160,7 +160,7 @@ function convertStringToArray(arrayLike) {
 * @return {string}
 */
 function formatDate(date) {
-    return ('0' + date.getDate()).slice(-2) + '/' + ('0' + (date.getMonth() + 1)).slice(-2) + '/' + date.getFullYear();
+    return ('0' + date.getUTCDate()).slice(-2) + '/' + ('0' + (date.getUTCMonth() + 1)).slice(-2) + '/' + date.getUTCFullYear();
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Create a release from a tag and uses issues or commits to creating the release notes. It also can generate a CHANGELOG.md file based on the release notes (or generate a brand new).",
     "main": "./github-release-notes.js",
     "scripts": {
+        "build": "gulp build",
         "start": "node github-release-notes.js",
         "test": "./node_modules/.bin/nyc mocha --reporter=nyan --compilers=js:babel-register",
         "coverage": "nyc --reporter=lcov --reporter=text mocha --compilers=js:babel-register",

--- a/test/Gren.spec.js
+++ b/test/Gren.spec.js
@@ -220,12 +220,10 @@ describe('Gren', () => {
                     'Others:': ['closed']
                 };
 
-                gren.options.groupPostProcessor = (groupContent) => {
-                    return groupContent.replace(0, groupContent.indexOf(':\n') + 3);
-                }
+                gren.options.groupPostProcessor = (groupContent) => groupContent.replace(0, groupContent.indexOf(':\n') + 3);
 
-                assert.deepEqual(gren._groupBy(normal), [`Test:`], 'Passing one heading for one issue');
-                assert.deepEqual(gren._groupBy(noLabel), [`Others:`], 'Group option is "label" with no labels');
+                assert.deepEqual(gren._groupBy(normal), [`Test:\nIssue with one label and milestone`], 'Passing one heading for one issue');
+                assert.deepEqual(gren._groupBy(noLabel), [`Others:\nIssue with no milestone and no labels`], 'Group option is "label" with no labels');
             });
         });
 


### PR DESCRIPTION
The logic for comparing dates tries to compare a string to a `Date` object. This causes additional pages of PRs to never be retrieved. This has been fixed.

Also, constructing a date used the local-specific date instead of UTC, which means that the tests would only pass if one ran them from a UTC timezone. The code was corrected to build the dates using UTC.

I found this problem when working on https://github.com/node-saml/passport-saml/issues/597