### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gren` 🤖
 
-> Github release notes and changelog generator
+> GitHub release notes and changelog generator
 
 [![npm version](https://badge.fury.io/js/github-release-notes.svg)](https://badge.fury.io/js/github-release-notes)
 [![Build Status](https://travis-ci.org/github-tools/github-release-notes.svg?branch=master)](https://travis-ci.org/github-tools/github-release-notes)

--- a/docs/_includes/header-home.html
+++ b/docs/_includes/header-home.html
@@ -7,7 +7,7 @@
     </h1>
     <p class="site-description">{{ site.description }}</p>
     <nav class="site-nav site-nav--center">
-        <a class="page-link" href="https://github.com/github-tools/github-release-notes">Github repo</a>
+        <a class="page-link" href="https://github.com/github-tools/github-release-notes">GitHub repo</a>
         {% for page in site.pages %}
             {% if page.title %}
                 <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,6 +1,6 @@
 <div class="site-header">
     <nav class="site-nav">
-        <a class="page-link" href="https://github.com/github-tools/github-release-notes">Github repo</a>
+        <a class="page-link" href="https://github.com/github-tools/github-release-notes">GitHub repo</a>
         {% for page in site.pages %}
             {% if page.title %}
                 <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "gren": "bin/gren.js"
     },
     "keywords": [
-        "Github",
+        "GitHub",
         "Release",
         "notes",
         "Tag",


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.